### PR TITLE
Allow Items with custom NBT to be added in special.yml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,9 +17,11 @@ java {
 
 repositories {
 	mavenCentral()
+	mavenLocal()
 	maven("https://papermc.io/repo/repository/maven-public/")
 	maven("https://repo.thbn.me/releases/")
-	maven("https://repo.thbn.me/snapshots/")
+	maven("https://repo.tehbrian.dev/snapshots/")
+	maven("https://repo.codemc.io/repository/maven-public/")
 }
 
 dependencies {
@@ -34,7 +36,8 @@ dependencies {
 	implementation("com.google.inject:guice:7.0.0")
 	implementation("org.spongepowered:configurate-yaml:4.1.2")
 	implementation("dev.tehbrian:tehlib-paper:0.6.0")
-	implementation("dev.tehbrian.restrictionhelper:restrictionhelper-spigot:0.4.1")
+	implementation("dev.tehbrian:restrictionhelper-spigot:0.5.0")
+	implementation("de.tr7zw:item-nbt-api:2.15.0")
 }
 
 tasks {
@@ -67,7 +70,7 @@ tasks {
 				"love.broccolai.corn",
 				"cloud.commandframework",
 				"com.google",
-				"dev.tehbrian.restrictionhelper",
+				"dev.tehbrian.restrictionhelper-spigot",
 				"dev.tehbrian.tehlib",
 				"io.leangen",
 				"jakarta.inject",
@@ -77,6 +80,7 @@ tasks {
 				"org.checkerframework",
 				"org.spongepowered",
 				"org.yaml",
+				"de.tr7zw.item-nbt-api"
 		)
 	}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,11 +17,11 @@ java {
 
 repositories {
 	mavenCentral()
-	mavenLocal()
 	maven("https://papermc.io/repo/repository/maven-public/")
 	maven("https://repo.thbn.me/releases/")
 	maven("https://repo.tehbrian.dev/snapshots/")
 	maven("https://repo.codemc.io/repository/maven-public/")
+	maven("https://repo.broccol.ai/snapshots/")
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,7 @@ tasks {
 				"org.checkerframework",
 				"org.spongepowered",
 				"org.yaml",
-				"de.tr7zw.item-nbt-api"
+				"de.tr7zw.changeme.nbtapi"
 		)
 	}
 

--- a/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
+++ b/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
@@ -42,23 +42,20 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 		}
 
 		for (final String dirtyItemName : itemNames) {
-			final var configItem = dirtyItemName.strip();
+			final String configItem = dirtyItemName.strip();
 
-			final Material itemMaterial;
 			try {
 				if (configItem.contains(", ")) {
 					this.items.add(this.itemFromString(configItem));
-					continue;
+				} else {
+					Material itemMaterial = Material.valueOf(configItem.toUpperCase());
+					this.items.add(new ItemStack(itemMaterial));
 				}
-				itemMaterial = Material.valueOf(configItem.toUpperCase());
 			} catch (final IllegalArgumentException e) {
 				this.logger.warn("The material {} does not exist.", configItem);
 				this.logger.warn("Skipping this item. Please check your {}", fileName);
 				this.logger.warn("Printing stack trace:", e);
-				continue;
 			}
-
-			this.items.add(new ItemStack(itemMaterial));
 		}
 	}
 

--- a/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
+++ b/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
@@ -6,9 +6,7 @@ import de.tr7zw.changeme.nbtapi.NBT;
 import de.tr7zw.changeme.nbtapi.iface.ReadableNBT;
 import dev.tehbrian.tehlib.configurate.AbstractConfig;
 import org.bukkit.Material;
-import org.bukkit.block.data.type.Light;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BlockDataMeta;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.spongepowered.configurate.CommentedConfigurationNode;
@@ -48,40 +46,9 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 			final var itemName = dirtyItemName.strip();
 			final String upperItemName = itemName.toUpperCase(Locale.ROOT);
 
-			// special case for light levels.
-			if (upperItemName.startsWith("LIGHT") && !upperItemName.equals("LIGHT")) {
-				int level;
-				try {
-					level = Integer.parseInt(itemName.split("-")[1]);
-				} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
-					this.logger.warn("Invalid light data {}.", itemName);
-					this.logger.warn("Skipping this item. Please check your {}", fileName);
-					this.logger.warn("Printing stack trace:", e);
-					continue;
-				}
-
-				if (level > 15) {
-					level = 15;
-				}
-				if (level < 0) {
-					level = 0;
-				}
-
-				// create a light item with that light level.
-				final ItemStack item = new ItemStack(Material.LIGHT);
-				final BlockDataMeta meta = (BlockDataMeta) item.getItemMeta();
-				final Light data = (Light) Material.LIGHT.createBlockData();
-				data.setLevel(level);
-				meta.setBlockData(data);
-				item.setItemMeta(meta);
-
-				this.items.add(item);
-				continue;
-			}
-
 			final Material itemMaterial;
 			try {
-				if (itemName.contains(" ")) {
+				if (itemName.contains(", ")) {
 					this.items.add(this.itemFromString(itemName));
 					continue;
 				}
@@ -102,7 +69,7 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 	}
 
 private ItemStack itemFromString(String string) {
-		String[] itemData = string.strip().split(" ", 2);
+		String[] itemData = string.strip().split(", ", 2);
 		Material material = Material.valueOf(itemData[0]);
 		ItemStack item = new ItemStack(material);
 

--- a/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
+++ b/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
@@ -15,7 +15,6 @@ import org.spongepowered.configurate.ConfigurateException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> {
 
@@ -44,7 +43,6 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 
 		for (final String dirtyItemName : itemNames) {
 			final var itemName = dirtyItemName.strip();
-			final String upperItemName = itemName.toUpperCase(Locale.ROOT);
 
 			final Material itemMaterial;
 			try {
@@ -52,7 +50,7 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 					this.items.add(this.itemFromString(itemName));
 					continue;
 				}
-				itemMaterial = Material.valueOf(upperItemName);
+				itemMaterial = Material.valueOf(itemName.toUpperCase());
 			} catch (final IllegalArgumentException e) {
 				this.logger.warn("The material {} does not exist.", itemName);
 				this.logger.warn("Skipping this item. Please check your {}", fileName);
@@ -68,9 +66,9 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 		return this.items;
 	}
 
-private ItemStack itemFromString(String string) {
+	private ItemStack itemFromString(String string) {
 		String[] itemData = string.strip().split(", ", 2);
-		Material material = Material.valueOf(itemData[0]);
+		Material material = Material.valueOf(itemData[0].toUpperCase());
 		ItemStack item = new ItemStack(material);
 
 		if (itemData.length > 1 && !itemData[1].isEmpty()) {

--- a/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
+++ b/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
@@ -70,11 +70,9 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 			if (itemData.length > 1 && !itemData[1].isBlank()) {
 				try {
 					ReadableNBT itemNBT = NBT.parseNBT(itemData[1]);
-					NBT.modifyComponents(
-							item, nbt -> {
-								nbt.mergeCompound(itemNBT);
-							}
-					);
+					NBT.modifyComponents(item, nbt -> {
+						nbt.mergeCompound(itemNBT);
+					});
 				} catch (Exception e) {
 					this.logger.warn("Invalid NBT data for item {}: {}", material, itemData[1], e);
 					return null;

--- a/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
+++ b/src/main/java/dev/tehbrian/buildersutilities/config/SpecialConfig.java
@@ -42,17 +42,17 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 		}
 
 		for (final String dirtyItemName : itemNames) {
-			final var itemName = dirtyItemName.strip();
+			final var configItem = dirtyItemName.strip();
 
 			final Material itemMaterial;
 			try {
-				if (itemName.contains(", ")) {
-					this.items.add(this.itemFromString(itemName));
+				if (configItem.contains(", ")) {
+					this.items.add(this.itemFromString(configItem));
 					continue;
 				}
-				itemMaterial = Material.valueOf(itemName.toUpperCase());
+				itemMaterial = Material.valueOf(configItem.toUpperCase());
 			} catch (final IllegalArgumentException e) {
-				this.logger.warn("The material {} does not exist.", itemName);
+				this.logger.warn("The material {} does not exist.", configItem);
 				this.logger.warn("Skipping this item. Please check your {}", fileName);
 				this.logger.warn("Printing stack trace:", e);
 				continue;
@@ -66,12 +66,12 @@ public final class SpecialConfig extends AbstractConfig<YamlConfigurateWrapper> 
 		return this.items;
 	}
 
-	private ItemStack itemFromString(String string) {
-		String[] itemData = string.strip().split(", ", 2);
+	private ItemStack itemFromString(String configItem) {
+		String[] itemData = configItem.strip().split(", ", 2);
 		Material material = Material.valueOf(itemData[0].toUpperCase());
 		ItemStack item = new ItemStack(material);
 
-		if (itemData.length > 1 && !itemData[1].isEmpty()) {
+		if (itemData.length > 1 && !itemData[1].isBlank()) {
 			try {
 				ReadableNBT itemNBT = NBT.parseNBT(itemData[1]);
 				NBT.modifyComponents(item, nbt -> {

--- a/src/main/resources/special.yml
+++ b/src/main/resources/special.yml
@@ -17,22 +17,22 @@ items:
   - STRUCTURE_VOID
   - BARRIER
   - DEBUG_STICK
-  - LIGHT-15
-  - LIGHT-14
-  - LIGHT-13
-  - LIGHT-12
-  - LIGHT-11
-  - LIGHT-10
-  - LIGHT-9
-  - LIGHT-8
-  - LIGHT-7
-  - LIGHT-6
-  - LIGHT-5
-  - LIGHT-4
-  - LIGHT-3
-  - LIGHT-2
-  - LIGHT-1
-  - LIGHT-0
+  - 'LIGHT, {"minecraft:block_state": {level: "15"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "14"}} '
+  - 'LIGHT, {"minecraft:block_state": {level: "13"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "12"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "11"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "10"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "9"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "8"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "7"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "6"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "5"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "4"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "3"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "2"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "1"}}'
+  - 'LIGHT, {"minecraft:block_state": {level: "0"}}'
 
   # Items below are not in the operator items menu.
   - KNOWLEDGE_BOOK
@@ -46,7 +46,7 @@ items:
   - PETRIFIED_OAK_SLAB
 
   # Items with special NBT
-  - 'ITEM_FRAME {"minecraft:entity_data": {id: "minecraft:item_frame", Invisible: 1b}, "minecraft:custom_name":''{text:"Invisible Item Frame"}''}'
+  - 'ITEM_FRAME, {"minecraft:entity_data": {id: "minecraft:item_frame", Invisible: 1b}, "minecraft:item_name":''{text:"Invisible Item Frame"}''}'
 
 # No touch!
 version: 1

--- a/src/main/resources/special.yml
+++ b/src/main/resources/special.yml
@@ -45,7 +45,7 @@ items:
   - TIPPED_ARROW
   - PETRIFIED_OAK_SLAB
 
-  # Items with special NBT
+  # Normal items with special NBT
   - 'ITEM_FRAME, {"minecraft:entity_data": {id: "minecraft:item_frame", Invisible: 1b}, "minecraft:item_name":''{text:"Invisible Item Frame"}''}'
 
 # No touch!

--- a/src/main/resources/special.yml
+++ b/src/main/resources/special.yml
@@ -45,5 +45,8 @@ items:
   - TIPPED_ARROW
   - PETRIFIED_OAK_SLAB
 
+  # Items with special NBT
+  - 'ITEM_FRAME {"minecraft:entity_data": {id: "minecraft:item_frame", Invisible: 1b}, "minecraft:custom_name":''{text:"Invisible Item Frame"}''}'
+
 # No touch!
 version: 1


### PR DESCRIPTION
This PR aims to allow the use of custom nbt items to be added in the special.yml file, utilizing the[ NBTAPI](https://github.com/tr7zw/Item-NBT-API/).
The build.gradle.kts has also been changed with updated versions and repositories, so that the project can be built again.
This fixes #71

Image of a new item with custom nbt in the menu:
![grafik](https://github.com/user-attachments/assets/ef1124f2-f145-403e-bfa9-ddd4d123c544)
